### PR TITLE
Await comp; make onSuccess async function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const htmlMinifier = require('@node-minify/html-minifier');
 
 module.exports = {
 
-  onSuccess: ({ inputs, constants }) => {
+  onSuccess: async ({ inputs, constants }) => {
 
     // Only continue in the selected deploy contexts
     if( !inputs.contexts.includes(process.env.CONTEXT) ) {
@@ -16,7 +16,7 @@ module.exports = {
     console.log('Minifiying HTML in the deploy context:', process.env.CONTEXT);
     console.log('Minifiying HTML with these options:', inputs.minifierOptions || "Default");
     try {
-      comp({
+      await comp({
         compressor: htmlMinifier,
         input: constants.PUBLISH_DIR + '/**/*.html',
         output: '$1.html',


### PR DESCRIPTION
Hi @philhawksworth,

I experienced the same issues as described in #2. It looks like `comp` returns a `Promise` and the node process running the `onSuccess` terminates before the Promise is resolved. As a result only some but not all files are minified. 

Proposing a solution here that waits for the Promise to be resolved, i.e. until all files are minified. 

--- 

**NOTE:** I verified the behaviour described above by making a local copy of `netlify-plugin-minify-html` and adding it to `netlify.toml`.

If I install `netlify-plugin-minify-html` from the plugin registry, it looks like ~no HTML files are minified at all~ only the `404.html` on [my site](https://github.com/oliverroick/oliverroick.github.io) , so this might not fully resolve issue #2. 