### PR TITLE
fix: switch to onPostBuild instead of onSuccess

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const htmlMinifier = require('@node-minify/html-minifier');
 
 module.exports = {
 
-  onSuccess: async ({ inputs, constants, utils }) => {
+  onPostBuild: async ({ inputs, constants, utils }) => {
 
     // Only continue in the selected deploy contexts
     if( !inputs.contexts.includes(process.env.CONTEXT) ) {


### PR DESCRIPTION
Hi @philhawksworth!

We're making a change to how `onSuccess` works.

**Current:**  `onSuccess` occurs after the build command is complete, but before any files are uploaded.
**Upcoming:** `onSuccess`  occurs after the site is deployed, live, and published to production (if applicable).

As a result of the upcoming change the functionality of this plugin will break.

This PR changes the plugin to work both with the current behaviour and the upcoming one.