### PR TITLE
Ensure text nodes don't have space removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ module.exports = {
         input: constants.PUBLISH_DIR + '/**/*.html',
         output: '$1.html',
         replaceInPlace: true,
-        options: inputs.minifierOptions
+        options: {
+          collapseWhitespace: false,
+          ...inputs.minifierOptions
+        }
       });
 
 


### PR DESCRIPTION
I'm not sure what's happening in the the plugin but the `collapseWhitespace` option is being set to `true` even when it's not set at all and the default being `false`, as [seen here in the docs for `html-minifier`](https://github.com/kangax/html-minifier#options-quick-reference).

I tried a couple of ways to prevent it returning true without luck, next best thing was to explicitly apply it and allow plugin users to overwrite it with the `minifierOptions` key in their `netlify.toml` file.

I'm hoping this will fix #13 #15 and #18. This issue has come up enough that I think it justifies being the default.

